### PR TITLE
update tests and some suggested changes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest~=6.2.3
 pytest-cov~=2.11.1
 pre-commit
 yapf==0.30.*
+vcrpy

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "python-dateutil>=2.7.0",
-        "boto3-utils>=0.3.2"
+        "boto3-utils>=0.3.2",
+        "jsonpath_ng>=1.5.3",
+        "requests>=2.28.1",
     ],
     extras_require={
         "validation": ["jsonschema>=4.0.1"],

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -10,6 +10,7 @@ import sys
 from tempfile import mkdtemp
 from typing import Dict, List, Optional, Union
 from xmlrpc.client import Boolean
+import itertools
 
 from boto3utils import s3
 from jsonpath_ng.ext import parser
@@ -20,7 +21,7 @@ from .asset_io import download_item_assets, upload_item_assets
 PathLike = Union[str, Path]
 
 
-'''
+"""
 Tasks can use parameters provided in a `process` Dictionary that is supplied in the ItemCollection
 JSON under the "process" field. An example process definition:
 
@@ -40,7 +41,7 @@ JSON under the "process" field. An example process definition:
     }
 }
 ```
-'''
+"""
 
 
 def stac_jsonpath_match(item: Dict, expr: str) -> Boolean:
@@ -67,14 +68,17 @@ def stac_jsonpath_match(item: Dict, expr: str) -> Boolean:
 
 class Task(ABC):
 
-    name = 'task'
-    description = 'A task for doing things'
-    version = '0.1.0'
+    name = "task"
+    description = "A task for doing things"
+    version = "0.1.0"
 
-    def __init__(self: "Task", item_collection: Dict,
-                 workdir: Optional[PathLike]=None,
-                 skip_validation: Optional[bool] = False,
-                 skip_upload: Optional[bool] = False):
+    def __init__(
+        self: "Task",
+        item_collection: Dict,
+        workdir: Optional[PathLike] = None,
+        skip_validation: Optional[bool] = False,
+        skip_upload: Optional[bool] = False,
+    ):
         # set up logger
         self.logger = logging.getLogger(self.name)
         # setup defaults
@@ -108,19 +112,19 @@ class Task(ABC):
 
     @property
     def process_definition(self) -> Dict:
-        return self._item_collection.get('process', {})
+        return self._item_collection.get("process", {})
 
     @property
     def parameters(self) -> Dict:
-        return self.process_definition.get('tasks', {}).get(self.name, {})
+        return self.process_definition.get("tasks", {}).get(self.name, {})
 
     @property
     def upload_options(self) -> Dict:
-        return self.process_definition.get('upload_options', {})
+        return self.process_definition.get("upload_options", {})
 
     @property
     def items(self) -> List[Dict]:
-        return self._item_collection['features']
+        return self._item_collection["features"]
 
     @classmethod
     def validate(cls, payload) -> bool:
@@ -129,38 +133,39 @@ class Task(ABC):
 
     @classmethod
     def add_software_version(cls, items):
-        processing_ext = 'https://stac-extensions.github.io/processing/v1.1.0/schema.json'
+        processing_ext = (
+            "https://stac-extensions.github.io/processing/v1.1.0/schema.json"
+        )
         for i in items:
-            i['stac_extensions'].append(processing_ext)
-            i['stac_extensions'] = list(set(i['stac_extensions']))
-            i['properties']['processing:software'] = {
-                cls.name: cls.version
-            }
+            i["stac_extensions"].append(processing_ext)
+            i["stac_extensions"] = list(set(i["stac_extensions"]))
+            i["properties"]["processing:software"] = {cls.name: cls.version}
         return items
 
     def assign_collections(self):
-        """Assigns new collection names based on
-        """
-        for i in self.items:
-            for col, expr in self.upload_options.get('collections').items():
-                if stac_jsonpath_match(i, expr):
-                    i['collection'] = col
+        """Assigns new collection names based on"""
+        for i, (coll, expr) in itertools.product(
+            self._item_collection["features"],
+            self.output_options.get("collections", dict()).items(),
+        ):
+            if stac_jsonpath_match(i, expr):
+                i["collection"] = col
 
-    def download_item_assets(self, item: Dict, assets: Optional[List[str]]=None):
+    def download_item_assets(self, item: Dict, assets: Optional[List[str]] = None):
         """Download provided asset keys for all items in payload. Assets are saved in workdir in a
            directory named by the Item ID, and the items are updated with the new asset hrefs.
 
         Args:
             assets (Optional[List[str]], optional): List of asset keys to download. Defaults to all assets.
         """
-        outdir = self._workdir / Path(item['id'])
+        outdir = self._workdir / Path(item["id"])
         makedirs(outdir, exist_ok=True)
         item = download_item_assets(item, path=outdir, assets=assets)
         return item
 
-    def upload_item_assets(self, item: Dict, assets: Optional[List[str]]=None):
+    def upload_item_assets(self, item: Dict, assets: Optional[List[str]] = None):
         if self._skip_upload:
-            self.logger.warn('Skipping upload of new and modified assets')
+            self.logger.warn("Skipping upload of new and modified assets")
             return item
         item = upload_item_assets(item, assets=assets, **self.upload_options)
         return item
@@ -170,15 +175,17 @@ class Task(ABC):
     def create_item_from_item(item):
         new_item = deepcopy(item)
         # create a derived output item
-        links = [l['href'] for l in item['links'] if l['rel'] == 'self']
+        links = [l["href"] for l in item["links"] if l["rel"] == "self"]
         if len(links) == 1:
             # add derived from link
-            item['links'].append({
-                'title': 'Source STAC Item',
-                'rel': 'derived_from',
-                'href': links[0],
-                'type': 'application/json'
-            })
+            item["links"].append(
+                {
+                    "title": "Source STAC Item",
+                    "rel": "derived_from",
+                    "href": links[0],
+                    "type": "application/json",
+                }
+            )
         return item
 
     @abstractmethod
@@ -189,9 +196,9 @@ class Task(ABC):
             [type]: [description]
         """
         # download assets of interest, this will update self.items
-        #self.download_assets(['key1', 'key2'])
+        # self.download_assets(['key1', 'key2'])
         # do some stuff
-        #self.upload_assets(['key1', 'key2'])
+        # self.upload_assets(['key1', 'key2'])
         return self.items
 
     @classmethod
@@ -199,7 +206,7 @@ class Task(ABC):
         task = cls(payload, **kwargs)
         try:
             items = task.process(**task.parameters)
-            task._item_collection['features'] = cls.add_software_version(items)
+            task._item_collection["features"] = cls.add_software_version(items)
             task.assign_collections()
             with open(task._workdir / "stac.json", "w") as f:
                 f.write(json.dumps(task._item_collection))
@@ -210,24 +217,37 @@ class Task(ABC):
 
     @classmethod
     def get_cli_parser(cls):
-        """ Parse CLI arguments """
+        """Parse CLI arguments"""
         dhf = argparse.ArgumentDefaultsHelpFormatter
         parser0 = argparse.ArgumentParser(description=cls.description)
-        parser0.add_argument('--version', help='Print version and exit', action='version', version=cls.version)
+        parser0.add_argument(
+            "--version",
+            help="Print version and exit",
+            action="version",
+            version=cls.version,
+        )
 
         pparser = argparse.ArgumentParser(add_help=False)
-        pparser.add_argument('--logging', default='INFO', help='DEBUG, INFO, WARN, ERROR, CRITICAL')
+        pparser.add_argument(
+            "--logging", default="INFO", help="DEBUG, INFO, WARN, ERROR, CRITICAL"
+        )
 
-        subparsers = parser0.add_subparsers(dest='command')
+        subparsers = parser0.add_subparsers(dest="command")
 
         # run
-        h = 'Process STAC Item Collection'
-        parser = subparsers.add_parser('run', parents=[pparser], help=h, formatter_class=dhf)
-        parser.add_argument('input', help='Full path of item collection to process (s3 or local)')
-        h = 'Use this as work directory. Will be created but not deleted)'
-        parser.add_argument('--workdir', help=h, default=None, type=Path)
-        h = 'Skip uploading of any generated assets and resulting STAC Items'
-        parser.add_argument('--skip-upload', dest='skip_upload', action='store_true', default=False)
+        h = "Process STAC Item Collection"
+        parser = subparsers.add_parser(
+            "run", parents=[pparser], help=h, formatter_class=dhf
+        )
+        parser.add_argument(
+            "input", help="Full path of item collection to process (s3 or local)"
+        )
+        h = "Use this as work directory. Will be created but not deleted)"
+        parser.add_argument("--workdir", help=h, default=None, type=Path)
+        h = "Skip uploading of any generated assets and resulting STAC Items"
+        parser.add_argument(
+            "--skip-upload", dest="skip_upload", action="store_true", default=False
+        )
         return parser0
 
     @classmethod
@@ -239,7 +259,7 @@ class Task(ABC):
         # only keep keys that are not None
         pargs = {k: v for k, v in pargs.items() if v is not None}
 
-        if pargs.get('command', None) is None:
+        if pargs.get("command", None) is None:
             parser.print_help()
             sys.exit(0)
 
@@ -248,20 +268,20 @@ class Task(ABC):
     @classmethod
     def cli(cls, parser=None):
         args = cls.parse_args(sys.argv[1:], parser=parser)
-        cmd = args.pop('command')
+        cmd = args.pop("command")
 
         # logging
-        loglevel = args.pop('logging')
+        loglevel = args.pop("logging")
         logging.basicConfig(level=loglevel)
 
         # quiet these loud loggers
-        quiet_loggers = ['botocore', 's3transfer', 'urllib3']
+        quiet_loggers = ["botocore", "s3transfer", "urllib3"]
         for ql in quiet_loggers:
             logging.getLogger(ql).propagate = False
 
-        if cmd == 'run':
-            href = args.pop('input')
-            if href.startswith('s3://'):
+        if cmd == "run":
+            href = args.pop("input")
+            if href.startswith("s3://"):
                 item_collection = s3().read_json(href)
             else:
                 # open local item collection

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -178,7 +178,7 @@ class Task(ABC):
         links = [l["href"] for l in item["links"] if l["rel"] == "self"]
         if len(links) == 1:
             # add derived from link
-            item["links"].append(
+            new_item["links"].append(
                 {
                     "title": "Source STAC Item",
                     "rel": "derived_from",
@@ -186,7 +186,7 @@ class Task(ABC):
                     "type": "application/json",
                 }
             )
-        return item
+        return new_item
 
     @abstractmethod
     def process(self, **kwargs) -> List[Dict]:

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -83,7 +83,7 @@ class Task(ABC):
         self.logger = logging.getLogger(self.name)
         # setup defaults
         self._tmpworkdir = False
-        self._workdir = workdir
+        self._workdir: Path = None
 
         if not skip_validation:
             if not self.validate(item_collection):
@@ -106,8 +106,8 @@ class Task(ABC):
 
     def __del__(self):
         # remove work directory if not running locally
-        if self._tmpworkdir:
-            self.logger.debug(f"Removing work directory {self._workdir}")
+        if self._tmpworkdir and self._workdir:
+            self.logger.debug("Removing work directory %s", self._workdir)
             rmtree(self._workdir)
 
     @property
@@ -149,7 +149,7 @@ class Task(ABC):
             self.output_options.get("collections", dict()).items(),
         ):
             if stac_jsonpath_match(i, expr):
-                i["collection"] = col
+                i["collection"] = coll
 
     def download_item_assets(self, item: Dict, assets: Optional[List[str]] = None):
         """Download provided asset keys for all items in payload. Assets are saved in workdir in a

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -289,4 +289,3 @@ class Task(ABC):
                     item_collection = json.loads(f.read())
             # run task handler
             output = cls.handler(item_collection, **args)
-            return output

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -75,28 +75,29 @@ class Task(ABC):
                  workdir: Optional[PathLike]=None,
                  skip_validation: Optional[bool] = False,
                  skip_upload: Optional[bool] = False):
+        # set up logger
+        self.logger = logging.getLogger(self.name)
+        # setup defaults
+        self._tmpworkdir = False
+        self._workdir = workdir
 
         if not skip_validation:
-            self.validate(item_collection)
+            if not self.validate(item_collection):
+                sys.exit(1)
 
         self._item_collection = item_collection
 
-        # set up logger
-        self.logger = logging.getLogger(self.name)
-
-        # skip uploading returned STAC Items and assets 
+        # skip uploading returned STAC Items and assets
         self._skip_upload = skip_upload
 
         # save any output options to be passed to
 
         # create temporary work directory if workdir is None
-        self._workdir = workdir
         if workdir is None:
             self._workdir = Path(mkdtemp())
             self._tmpworkdir = True
         else:
             self._workdir = Path(workdir)
-            self._tmpworkdir = False
             makedirs(self._workdir, exist_ok=True)
 
     def __del__(self):
@@ -252,7 +253,7 @@ class Task(ABC):
         # logging
         loglevel = args.pop('logging')
         logging.basicConfig(level=loglevel)
-    
+
         # quiet these loud loggers
         quiet_loggers = ['botocore', 's3transfer', 'urllib3']
         for ql in quiet_loggers:

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -141,7 +141,7 @@ class Task(ABC):
         """Assigns new collection names based on"""
         for i, (coll, expr) in itertools.product(
             self._item_collection["features"],
-            self.output_options.get("collections", dict()).items(),
+            self.upload_options.get("collections", dict()).items(),
         ):
             if stac_jsonpath_match(i, expr):
                 i["collection"] = coll

--- a/tests/fixtures/sentinel2-items.json
+++ b/tests/fixtures/sentinel2-items.json
@@ -478,7 +478,7 @@
             "path_template": "s3://sentinel-cogs/${collection}/${sentinel:utm_zone}/${sentinel:latitude_band}/${sentinel:grid_square}/${year}/${month}/${id}",
             "public_assets": "ALL",
             "collections": {
-                "sentinel-s2-l2a-cogs": ".*"
+              "sentinel-s2-l2a-cogs": "$[?(@.id =~ 'S2[AB].*')]"
             },
             "headers": {
                 "CacheControl": "public, max-age=31536000, immutable"

--- a/tests/fixtures/sentinel2-items.json
+++ b/tests/fixtures/sentinel2-items.json
@@ -474,7 +474,7 @@
             "sentinel-s2-l2a"
         ],
         "workflow": "cog-archive",
-        "output_options": {
+        "upload_options": {
             "path_template": "s3://sentinel-cogs/${collection}/${sentinel:utm_zone}/${sentinel:latitude_band}/${sentinel:grid_square}/${year}/${month}/${id}",
             "public_assets": "ALL",
             "collections": {

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -37,10 +37,10 @@ def get_test_items(name='sentinel2-items'):
 def test_task_init():
     item_collection = get_test_items()
     t = NothingTask(item_collection)
-    assert(len(t._item_collection['features']) == 1)
-    assert(len(t.items) == 1)
-    assert(str(t._workdir).startswith('/tmp'))
-    assert(t.logger.name == 'nothing-task')
+    assert len(t._item_collection["features"]) == 1
+    assert len(t.items) == 1
+    assert t.logger.name == t.name
+    assert t._tmpworkdir == True
 
 
 def test_edit_items():
@@ -58,13 +58,12 @@ def test_edit_items():
 
 def test_tmp_workdir():
     t = NothingTask(get_test_items())
-    assert(t._tmpworkdir == True)
+    assert t._tmpworkdir == True
     workdir = t._workdir
-    assert(workdir.parts[1] == 'tmp')
-    assert(workdir.parts[2].startswith('tmp'))
-    assert(workdir.is_dir() == True)
+    assert workdir.parts[-1].startswith("tmp")
+    assert workdir.is_dir() == True
     del t
-    assert(workdir.is_dir() == False)
+    assert workdir.is_dir() == False
 
 
 def test_workdir():
@@ -106,8 +105,10 @@ def test_task_handler():
     items = get_test_items()
     self_link = [l for l in items['features'][0]['links'] if l['rel'] == 'self'][0]
     output_items = DerivedItemTask.handler(items)
-    derived_link = [l for l in output_items[0]['links'] if l['rel'] == 'derived_from'][0]
-    assert(derived_link['href'] == self_link['href'])
+    derived_link = [
+        l for l in output_items["features"][0]["links"] if l["rel"] == "derived_from"
+    ][0]
+    assert derived_link["href"] == self_link["href"]
 
 
 #@vcr.use_cassette(str(cassettepath/'download_assets'))

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -81,8 +81,11 @@ def test_workdir():
 def test_parameters():
     items = get_test_items()
     t = NothingTask(items)
-    assert(t.process_definition['workflow'] == 'cog-archive')
-    assert(t.output_options['path_template'] == items['process']['output_options']['path_template'])
+    assert t.process_definition["workflow"] == "cog-archive"
+    assert (
+        t.upload_options["path_template"]
+        == items["process"]["upload_options"]["path_template"]
+    )
 
 
 def test_process():


### PR DESCRIPTION
In the process of using the STAC Task class, I encountered some issues that I think these commits address, and would benefit anyone using this.  Curious what @matthewhanson thinks about number 5.

1. If this moves to stactools, maybe the added requirements would already be present.
2. Tests updated, and now all pass.
3. dangling references to `output_options` removed
4. tried to keep `python-black` from changing every line.
5. Dropped the `return output` from the `Task.cli`, since this blows up the terminal with the `_item_collection`.