### PR TITLE
Ensure workdir is always an absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Ensure `workdir` is an absolute path
+  ([#54](https://github.com/stac-utils/stac-task/pull/51)).
 - When a `workdir` is set for a `Task` the `workdir` will no longer be removed
-  by default [#51](https://github.com/stac-utils/stac-task/pull/51)). That is,
+  by default ([#51](https://github.com/stac-utils/stac-task/pull/51)). That is,
   the `save_workdir` argument to `Task` constructor now defaults to `None`, and
   if left as `None` the default behavior is now conditional on whether or not a
       `workdir` is specified.

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -85,7 +85,7 @@ class Task(ABC):
             # if we are using a temp workdir we want to rm by default
             self._save_workdir = save_workdir if save_workdir is not None else False
         else:
-            self._workdir = Path(workdir)
+            self._workdir = Path(workdir).absolute()
             makedirs(self._workdir, exist_ok=True)
             # if a workdir was specified we don't want to rm by default
             self._save_workdir = save_workdir if save_workdir is not None else True

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -61,6 +61,7 @@ def test_tmp_workdir(items: Dict[str, Any], save_workdir: Optional[bool]) -> Non
     assert nothing_task._save_workdir is expected
     workdir = nothing_task._workdir
     assert workdir.parts[-1].startswith("tmp")
+    assert workdir.is_absolute() is True
     assert workdir.is_dir() is True
     del nothing_task
     assert workdir.is_dir() is expected
@@ -77,6 +78,7 @@ def test_workdir(
     assert t._save_workdir is expected
     workdir = t._workdir
     assert workdir.parts[-1] == "test_task"
+    assert workdir.is_absolute() is True
     assert workdir.is_dir() is True
     del t
     assert workdir.is_dir() is expected


### PR DESCRIPTION
I ran into some issues with workdir not being absolute, specifically with stac-asset trying to download remote assets for an item with some local assets with hrefs based on the workdir and therefore non-absolute paths. Forcing the workdir path to be absolute works around this issue.

I think this change also helps in the case where processing code changes the working directory for some reason. As relative paths are interpreted relative to the cwd, changing the cwd could cause really bad things to happen if the workdir path is not absolute.