### PR TITLE
Give more informative validation errors

### DIFF
--- a/stactask/task.py
+++ b/stactask/task.py
@@ -157,6 +157,8 @@ class Task(ABC):
 
     @classmethod
     def validate(cls, payload: Dict[str, Any]) -> bool:
+        """Validates the payload and returns True if valid. If invalid, raises
+        ``stactask.exceptions.FailedValidation`` or returns False."""
         # put validation logic on input Items and process definition here
         return True
 

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 from stactask import Task
+from stactask.exceptions import FailedValidation
 
 
 class NothingTask(Task):
@@ -17,7 +18,9 @@ class FailValidateTask(Task):
 
     @classmethod
     def validate(self, payload: Dict[str, Any]) -> bool:
-        return False
+        if payload:
+            raise FailedValidation("Extra context about what went wrong")
+        return True
 
     def process(self, **kwargs: Any) -> List[Dict[str, Any]]:
         return self.items_as_dicts

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -41,7 +41,7 @@ def test_task_init(nothing_task: Task) -> None:
 
 
 def test_failed_validation(items: Dict[str, Any]) -> None:
-    with pytest.raises(FailedValidation):
+    with pytest.raises(FailedValidation, match="Extra context"):
         FailValidateTask(items)
 
 


### PR DESCRIPTION
Closes #35 

I figure the tasks themselves need to tell us why the payload is invalid, but this does require tasks to re-write their validate methods.