### PR TITLE
cleanup workdir correctly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,17 +16,17 @@ repos:
         args: [--ignore-words=.codespellignore]
         types_or: [jupyter, markdown, python, shell]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.12.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.0
+    rev: v1.7.1
     hooks:
       - id: mypy
         additional_dependencies:
           - pytest
           - types-setuptools == 65.7.0.3
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.8
     hooks:
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased - TBD
+
+### Changed
+
+- handler now explicitly calls performs workdir cleanup
+- workdir cleanup is correctly defensive and logs errors
+
 ## [v0.2.0] - 2023-11-16
 
 ### Changed

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -65,13 +65,9 @@ class Task(ABC):
         skip_upload: bool = False,
         skip_validation: bool = False,
     ):
-        # define these to avoid undefined in destructor if init fails
-        self._save_workdir = True
-
-        # set up logger
         self.logger = logging.getLogger(self.name)
 
-        # validate input payload...or not
+        # validate input payload... or not
         if not skip_validation:
             if not self.validate(payload):
                 raise FailedValidation()

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -67,7 +67,6 @@ class Task(ABC):
     ):
         # define these to avoid undefined in destructor if init fails
         self._save_workdir = True
-        self._workdir = Path()
 
         # set up logger
         self.logger = logging.getLogger(self.name)
@@ -91,12 +90,6 @@ class Task(ABC):
             makedirs(self._workdir, exist_ok=True)
             # if a workdir was specified we don't want to rm by default
             self._save_workdir = save_workdir if save_workdir is not None else True
-
-    def __del__(self) -> None:
-        try:
-            self.cleanup_workdir()
-        except:  # noqa: E722
-            pass
 
     @property
     def process_definition(self) -> Dict[str, Any]:
@@ -201,15 +194,19 @@ class Task(ABC):
         return item
 
     def cleanup_workdir(self) -> None:
-        # remove work directory if not configured to save it
-        if not self._save_workdir and self._workdir and os.path.exists(self._workdir):
-            self.logger.debug("Removing work directory %s", self._workdir)
-            try:
+        """Remove work directory if configured not to save it"""
+        try:
+            if (
+                not self._save_workdir
+                and self._workdir
+                and os.path.exists(self._workdir)
+            ):
+                self.logger.debug("Removing work directory %s", self._workdir)
                 rmtree(self._workdir)
-            except Exception as e:
-                self.logger.warning(
-                    "Failed removing work directory %s: %s", self._workdir, e
-                )
+        except Exception as e:
+            self.logger.warning(
+                "Failed removing work directory %s: %s", self._workdir, e
+            )
 
     def assign_collections(self) -> None:
         """Assigns new collection names based on"""

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -56,15 +56,15 @@ def test_edit_items2(nothing_task: Task) -> None:
 
 @pytest.mark.parametrize("save_workdir", [False, True, None])
 def test_tmp_workdir(items: Dict[str, Any], save_workdir: Optional[bool]) -> None:
-    nothing_task = NothingTask(items, save_workdir=save_workdir)
+    t = NothingTask(items, save_workdir=save_workdir)
     expected = save_workdir if save_workdir is not None else False
-    assert nothing_task._save_workdir is expected
-    workdir = nothing_task._workdir
+    assert t._save_workdir is expected
+    workdir = t._workdir
     assert workdir.parts[-1].startswith("tmp")
     assert workdir.is_absolute() is True
     assert workdir.is_dir() is True
-    del nothing_task
-    assert workdir.is_dir() is expected
+    t.cleanup_workdir()
+    assert workdir.exists() is expected
 
 
 @pytest.mark.parametrize("save_workdir", [False, True, None])
@@ -80,8 +80,8 @@ def test_workdir(
     assert workdir.parts[-1] == "test_task"
     assert workdir.is_absolute() is True
     assert workdir.is_dir() is True
-    del t
-    assert workdir.is_dir() is expected
+    t.cleanup_workdir()
+    assert workdir.exists() is expected
 
 
 def test_parameters(items: Dict[str, Any]) -> None:


### PR DESCRIPTION
This handles a few issues with the existing workdir cleanup:

1) Only doing this in __del__ did not guarantee it would ever be called, as Python does not guarantee `__del__` is called before the interpreter exists (see https://docs.python.org/3/reference/datamodel.html#object.__del__ , "It is not guaranteed that __del__() methods are called for objects that still exist when the interpreter exits.")
2) __del__ can be called in __init__, which would throw an exception because _workdir would be undefined.

Changes:

1) handler now explicitly calls workdir_cleanup
2) workdir_cleanup is correctly defensive and logs errors
3) __del__ will never throw a cleanup exception (not very relevant now, but important if additional `__del__` operations are added in the future.