### PR TITLE
add support for non-async filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Given that `_get_file` is part of the `AsyncFileSystem` spec,
-  this adds the synchronous `get_file` as a way to retrieve files if
-  `_get_file` is not found.
+- ([#72]) Given that `_get_file` is part of the `AsyncFileSystem` spec, this
+  adds the synchronous `get_file` as a way to retrieve files if `_get_file` is
+  not found.
 
 ## [v0.3.0] - 2023-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Given that `_get_file` is part of the `AsyncFileSystem` spec,
+  this adds the synchronous `get_file` as a way to retrieve files if
+  `_get_file` is not found.
+
 ## [v0.3.0] - 2023-12-20
 
 ### Changed

--- a/stactask/asset_io.py
+++ b/stactask/asset_io.py
@@ -22,7 +22,15 @@ sem = asyncio.Semaphore(SIMULTANEOUS_DOWNLOADS)
 async def download_file(fs: AbstractFileSystem, src: str, dest: str) -> None:
     async with sem:
         logger.debug(f"{src} start")
-        await fs._get_file(src, dest)
+        if hasattr(fs, "_get_file"):
+            await fs._get_file(src, dest)
+        elif hasattr(fs, "get_file"):
+            fs.get_file(src, dest)
+        else:
+            raise NotImplementedError(
+                "stactask only supports filesystems providing"
+                " `get_file` or `_get_file` interface"
+            )
         logger.debug(f"{src} completed")
 
 

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -36,6 +36,24 @@ def test_download_item_asset(tmp_path: Path, item_collection: Dict[str, Any]) ->
 
 
 # @vcr.use_cassette(str(cassettepath / 'download_assets'))
+def test_download_item_asset_local(
+    tmp_path: Path, item_collection: Dict[str, Any]
+) -> None:
+    t = NothingTask(item_collection, workdir=tmp_path / "test-task-download-item-asset")
+    item = t.download_item_assets(t.items[0], assets=["tileinfo_metadata"])
+    fname = item.assets["tileinfo_metadata"].href
+    filename = Path(fname)
+    assert filename.is_file() is True
+    item = t.download_item_assets(
+        item, assets=["tileinfo_metadata"], path_template="again/${collection}/${id}"
+    )
+    fname = item.assets["tileinfo_metadata"].href
+    assert "again" in fname
+    filename = Path(fname)
+    assert filename.is_file() is True
+
+
+# @vcr.use_cassette(str(cassettepath / 'download_assets'))
 def test_download_item_assets(tmp_path: Path, item_collection: Dict[str, Any]) -> None:
     t = NothingTask(
         item_collection,

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -48,9 +48,9 @@ def test_download_item_asset_local(
     item = t.download_item_assets(
         item, assets=["tileinfo_metadata"], path_template="again/${collection}/${id}"
     )
-    fname = item.assets["tileinfo_metadata"].href
-    assert "again" in fname
-    filename = Path(fname)
+    href = item.assets["tileinfo_metadata"].href
+    assert "again" in href
+    filename = Path(href)
     assert filename.is_file() is True
 
 

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -43,6 +43,8 @@ def test_download_item_asset_local(
     fname = item.assets["tileinfo_metadata"].href
     filename = Path(fname)
     assert filename.is_file() is True
+    # Downloaded to local, as in prev test.
+    # With the asset hrefs updated by the prev download, we "download" again to subdir
     item = t.download_item_assets(
         item, assets=["tileinfo_metadata"], path_template="again/${collection}/${id}"
     )

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -35,7 +35,6 @@ def test_download_item_asset(tmp_path: Path, item_collection: Dict[str, Any]) ->
     assert filename.is_file() is True
 
 
-# @vcr.use_cassette(str(cassettepath / 'download_assets'))
 def test_download_item_asset_local(
     tmp_path: Path, item_collection: Dict[str, Any]
 ) -> None:


### PR DESCRIPTION
In particular, it can happen that a stac-task is copying between file systems using the LocalFileSystem implementation, and that doesn't provide the async interface.