### PR TITLE
don't transform hrefs when making a copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.4.1] - 2024-03-06
+
+### Fixed
+
+- ([#90](https://github.com/stac-utils/stac-task/pull/90)) block asset_io
+  module from reaching out to upstream stac APIs (especially on NASA Wednesdays
+  `transform_hrefs=False`)
+
 ## [v0.4.0] - 2024-02-14
 
 ### Fixed
@@ -57,7 +65,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release.
 
-<!-- [Unreleased]: <https://github.com/stac-utils/stac-task/compare/v0.1.1...main> -->
+<!-- [unreleased]: <https://github.com/stac-utils/stac-task/compare/v0.4.1...main>-->
+[v0.4.1]: <https://github.com/stac-utils/stac-task/compare/v0.4.0...v0.4.1>
 [v0.4.0]: <https://github.com/stac-utils/stac-task/compare/v0.3.0...v0.4.0>
 [v0.3.0]: <https://github.com/stac-utils/stac-task/compare/v0.2.0...v0.3.0>
 [v0.2.0]: <https://github.com/stac-utils/stac-task/compare/v0.1.1...v0.2.0>

--- a/stactask/asset_io.py
+++ b/stactask/asset_io.py
@@ -125,7 +125,7 @@ def upload_item_assets_to_s3(
         headers = {}
 
     # deepcopy of item
-    _item = item.to_dict()
+    _item = item.to_dict(transform_hrefs=False)
 
     if public_assets is None:
         public_assets = []


### PR DESCRIPTION
Easy fix, which I'm including prep for a bugfix release 0.4.1.