### PR TITLE
Support explicitly specifying the boto3utils3.s3 object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+
+### Added
+
+- ([#xx](https://github.com/stac-utils/stac-task/pull/xx)) Task.upload_item_assets_to_s3 and asset_io.upload_item_assets_to_s3 support explicitly specifying the boto3utils3.s3 object.
+
 ## [v0.4.1] - 2024-03-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - TBD
+## [unreleased] - TBD
 
 ### Added
 
-- ([#xx](https://github.com/stac-utils/stac-task/pull/xx)) Task.upload_item_assets_to_s3 and asset_io.upload_item_assets_to_s3 support explicitly specifying the boto3utils3.s3 object.
+- ([#92](https://github.com/stac-utils/stac-task/pull/92)) Task.upload_item_assets_to_s3 and asset_io.upload_item_assets_to_s3 support explicitly specifying the boto3utils3.s3 object.
 
 ## [v0.4.1] - 2024-03-06
 
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release.
 
-<!-- [unreleased]: <https://github.com/stac-utils/stac-task/compare/v0.4.1...main>-->
+[unreleased]: <https://github.com/stac-utils/stac-task/compare/v0.4.1...main>
 [v0.4.1]: <https://github.com/stac-utils/stac-task/compare/v0.4.0...v0.4.1>
 [v0.4.0]: <https://github.com/stac-utils/stac-task/compare/v0.3.0...v0.4.0>
 [v0.3.0]: <https://github.com/stac-utils/stac-task/compare/v0.2.0...v0.3.0>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "pre-commit~=3.5.0",
     "pytest-cov~=4.1.0",
     "pytest~=8.0",
-    "ruff==0.3.0",
+    "ruff~=0.3.1",
     "types-setuptools~=69.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ strict = true
 module = ["boto3utils", "jsonpath_ng.ext", "fsspec"]
 ignore_missing_imports = true
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["F", "E", "W", "I", "ERA", "RUF"]

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -15,6 +15,7 @@ from tempfile import mkdtemp
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 import fsspec
+from boto3utils import s3
 from pystac import Item, ItemCollection
 
 from .asset_io import (
@@ -279,12 +280,17 @@ class Task(ABC):
         return list(items)
 
     def upload_item_assets_to_s3(
-        self, item: Item, assets: Optional[List[str]] = None
+        self,
+        item: Item,
+        assets: Optional[List[str]] = None,
+        s3_client: Optional[s3] = None,
     ) -> Item:
         if self._skip_upload:
             self.logger.warning("Skipping upload of new and modified assets")
             return item
-        item = upload_item_assets_to_s3(item, assets=assets, **self.upload_options)
+        item = upload_item_assets_to_s3(
+            item=item, assets=assets, s3_client=s3_client, **self.upload_options
+        )
         return item
 
     # this should be in PySTAC


### PR DESCRIPTION
Task.upload_item_assets_to_s3 and asset_io.upload_item_assets_to_s3 support explicitly specifying the boto3utils3.s3 object

This allows greater flexibility in setting various AWS S3 parameters, which allows this to support S3-compatible APIs like MinIO.