### PR TITLE
don't add processing:software to items automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - TBD
+
+### Changed
+
+- The `processing:software` field is no longer added to Items by default. This is
+  because the intention of the STAC Processing Extension is to add metadata about the
+  processing of the data, whereas stactask is frequently used only for processing
+  metadata. Users wishing to retain this field can call the method `Task.add_software_version_to_item(item)` on the resulting item to add it.
+
 ## [v0.4.2] - 2024-03-08
 
 ### Added
@@ -71,7 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release.
 
-<!-- [unreleased]: <https://github.com/stac-utils/stac-task/compare/v0.4.1...main> -->
+[unreleased]: <https://github.com/stac-utils/stac-task/compare/v0.4.2...main>
 [v0.4.2]: <https://github.com/stac-utils/stac-task/compare/v0.4.1...v0.4.2>
 [v0.4.1]: <https://github.com/stac-utils/stac-task/compare/v0.4.0...v0.4.1>
 [v0.4.0]: <https://github.com/stac-utils/stac-task/compare/v0.3.0...v0.4.0>

--- a/stactask/task.py
+++ b/stactask/task.py
@@ -340,7 +340,6 @@ class Task(ABC):
         Returns:
             Dict[str, Any]: The item with any additional attributes applied.
         """
-        item = self.add_software_version_to_item(item)
         assert "stac_extensions" in item
         assert isinstance(item["stac_extensions"], list)
         item["stac_extensions"].sort()

--- a/tests/fixtures/sentinel2-l2a-j2k-payload.json
+++ b/tests/fixtures/sentinel2-l2a-j2k-payload.json
@@ -61,9 +61,6 @@
                 "sentinel2:processing_baseline": "04.00",
                 "datetime": "2022-10-07T01:16:42.073000Z",
                 "sentinel2:id": "S2A_OPER_MSI_L2A_TL_ATOS_20221007T034556_A038080_T52HGH",
-                "processing:software": {
-                    "sentinel2-to-stac": "0.1.0"
-                },
                 "created": "2022-10-07T05:12:48.954Z",
                 "updated": "2022-10-07T05:12:48.954Z"
             },
@@ -849,9 +846,6 @@
                 "sentinel2:processing_baseline": "04.00",
                 "datetime": "2022-10-09T16:27:07.934000Z",
                 "sentinel2:id": "S2B_OPER_MSI_L2A_TL_2BPS_20221009T203656_A029209_T05CNL",
-                "processing:software": {
-                    "sentinel2-to-stac": "0.1.0"
-                },
                 "created": "2022-10-09T22:36:20.098Z",
                 "updated": "2022-10-09T22:36:20.098Z"
             },

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -111,7 +111,6 @@ def test_post_process(items: Dict[str, Any]) -> None:
     payload = PostProcessTask.handler(items)
     for item in payload["features"]:
         assert item["properties"]["foo"] == "bar"
-        assert item["properties"]["processing:software"]["post-processing-test"] == "42"
         stac_extensions = item["stac_extensions"]
         assert item["stac_extensions"] == sorted(stac_extensions)
 
@@ -131,10 +130,6 @@ def test_task_handler(items: Dict[str, Any]) -> None:
         lk for lk in output_items["features"][0]["links"] if lk["rel"] == "derived_from"
     )
     assert derived_link["href"] == self_link["href"]
-    assert (
-        "derived-item-task"
-        in output_items["features"][0]["properties"]["processing:software"]
-    )
 
 
 def test_parse_no_args() -> None:


### PR DESCRIPTION
- https://github.com/stac-utils/stac-task/issues/58

This PR stops adding the processing:software attribute to Items, as this is intended to be the data processing software, and the stactask is most frequently used for metadata processing.