### PR TITLE
Refactor file name extraction using urlparse

### DIFF
--- a/stactask/asset_io.py
+++ b/stactask/asset_io.py
@@ -3,6 +3,7 @@ import logging
 import os
 from os import path as op
 from typing import Any, Dict, Iterable, List, Optional, Union
+from urllib.parse import urlparse
 
 import fsspec
 from boto3utils import s3
@@ -62,10 +63,11 @@ async def download_item_assets(
         href = item.assets[a].href
 
         # local filename
+        url_path = urlparse(href).path
         if keep_original_filenames:
-            basename = os.path.basename(href)
+            basename = os.path.basename(url_path)
         else:
-            basename = a + os.path.splitext(href)[1]
+            basename = a + os.path.splitext(url_path)[1]
         new_href = os.path.join(path, basename)
         if absolute_path:
             new_href = os.path.abspath(new_href)


### PR DESCRIPTION
Currently `stack-task` encounters issues with presigned URLs, resulting in the following error when attempting to create a file with a name that includes the part after the `?` symbol:
```
OSError: [Errno 36] File name too long
```

```
>>> href = "http://foo.bar/raster.tif?x-user=no-user-in-request&X-Amz-Algorithm="
>>> basename = os.path.basename(href)
>>> new_href = os.path.join("", basename)
>>> new_href
'raster.tif?x-user=no-user-in-request&X-Amz-Algorithm='
```

This pull request aims to resolve this issue.