### PR TITLE
add Task.upload_local_item_assets_to_s3 method

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,10 +23,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - name: Install
+      - name: Install dependencies for linting
         run: pip install '.[dev]'
       - name: Lint
         run: pre-commit run --all-files
+      - name: Install dependencies for testing
+        run: pip install '.[test]'
       - name: Test
         run: pytest
   codecov:
@@ -41,7 +43,7 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install
-        run: pip install '.[dev]'
+        run: pip install '.[test]'
       - name: Test
         run: pytest --cov=stactask
       - name: Upload coverage to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Utils method `find_collection` to allow the retrieval of the collection name for
   an Item dict
 - Task method `upload_local_item_assets_to_s3(item)` to upload all local assets to S3
-
-## Added
-
 - Added support for using stdin and stdout as input and output for task, e.g., `cat in.json | src/mytask/mytask.py run --local | tee out.json`
 
 ## [v0.4.2] - 2024-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Added
 
-- Added property `collection_mapping` to `Task` class to retrieve the collection mappings
+- Property `collection_mapping` to `Task` class to retrieve the collection mappings
   from upload_options
-- Added utils method `find_collection` to allow the retrieval of the collection name for
+- Utils method `find_collection` to allow the retrieval of the collection name for
   an Item dict
+- Task method `upload_local_item_assets_to_s3(item)` to upload all local assets to S3
 
 ## Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,13 @@ dev = [
     "codespell~=2.2.5",
     "mypy~=1.9",
     "pre-commit~=3.7",
-    "pytest-cov~=5.0",
-    "pytest~=8.0",
     "ruff~=0.3.1",
     "types-setuptools~=69.0",
+]
+test = [
+    "pytest~=8.0",
+    "pytest-cov~=5.0",
+    "pytest-env~=1.1",
     "moto~=5.0.5",
 ]
 
@@ -69,4 +72,5 @@ env = [
     "AWS_SESSION_TOKEN=baz",
 ]
 filterwarnings = [
+    "ignore::UserWarning:stactask.*:",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pytest~=8.0",
     "ruff~=0.3.1",
     "types-setuptools~=69.0",
+    "moto~=5.0.5",
 ]
 
 [project.urls]
@@ -55,3 +56,17 @@ ignore_missing_imports = true
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "I", "ERA", "RUF"]
+
+[tool.pytest.ini_options]
+addopts = "-rx -q -s -vvv"
+log_cli_level = "INFO"
+log_cli = true
+markers = ["system", "unit"]
+env = [
+    "AWS_DEFAULT_REGION=us-west-2",
+    "AWS_ACCESS_KEY_ID=foo",
+    "AWS_SECRET_ACCESS_KEY=bar",
+    "AWS_SESSION_TOKEN=baz",
+]
+filterwarnings = [
+]

--- a/tests/fixtures/sentinel2-l2a-j2k-payload.json
+++ b/tests/fixtures/sentinel2-l2a-j2k-payload.json
@@ -7,7 +7,7 @@
         ],
         "workflow": "cog-archive",
         "upload_options": {
-            "path_template": "s3://sentinel-cogs/${collection}/${grid:utm_zone}/${grid:latitude_band}/${grid:grid_square}/${year}/${month}/${id}",
+            "path_template": "s3://sentinel-cogs/${collection}/${mgrs:utm_zone}/${mgrs:latitude_band}/${mgrs:grid_square}/${year}/${month}/${id}",
             "public_assets": "ALL",
             "collections": {
                 "sentinel-2-l2a": "$[?(@.id =~ 'S2[AB].*')]"


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-task/issues/108


**Proposed Changes:**

1. Add upload_local_item_assets_to_s3 method that uploads all local items (in workdir) to S3.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
