### PR TITLE
remove support for Python 3.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Deprecated
 
+- Support for Python 3.8 has been removed.
 - CLI flags `--skip-upload` and `--skip-validation` deprecated in favor of `--upload/--no-upload` and `--validate/no-validate`
 - Task constructor arguments `skip_upload` and `skip_validation` deprecated in favor of `upload` and `validate`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{ name = "Matthew Hanson", email = "matt.a.hanson@gmail.com" }]
 maintainers = [{ name = "Pete Gadomski", email = "pete.gadomski@gmail.com" }]
 description = "Class interface for running custom algorithms and workflows on STAC Items"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["pystac", "imagery", "raster", "catalog", "STAC"]
 license = { text = "Apache-2.0" }
 classifiers = [
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -35,7 +34,7 @@ dev = [
     "black~=24.0",
     "codespell~=2.2.5",
     "mypy~=1.9",
-    "pre-commit~=3.5",        # Need to allow down to v3.5 until we drop Python 3.8
+    "pre-commit~=3.7",
     "pytest-cov~=5.0",
     "pytest~=8.0",
     "ruff~=0.3.1",


### PR DESCRIPTION
**Related Issue(s):**

- n/a


**Proposed Changes:**

1. Python 3.8 is EOL this year, so there are no new projects that should be using it, and existing projects don't need to update to the next major-minor.
2. In the last two changes I've tried to make, I've had incompatibilities with 3.8 that have required a workaround, so supporting it is becoming a burden.

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
