### PR TITLE
add correct typing to the logger after removing 3.8

### DIFF
--- a/stactask/logging.py
+++ b/stactask/logging.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    _LoggerAdapter = logging.LoggerAdapter[logging.Logger]  # pragma: no cover
+else:
+    _LoggerAdapter = logging.LoggerAdapter
 
 
-class TaskLoggerAdapter(logging.LoggerAdapter):  # type: ignore
+class TaskLoggerAdapter(_LoggerAdapter):
     def __init__(self, logger: logging.Logger, prefix: Optional[str]) -> None:
         super().__init__(logger, {})
         self.prefix = prefix


### PR DESCRIPTION
**Related Issue(s):**

- n/a


**Proposed Changes:**

1. add correct typing to the logger after removing 3.8 (since the typing wouldn't work with 3.8)

**PR Checklist:**

- [X] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
