### PR TITLE
165: Add workflow-level option support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - ([#167](https://github.com/stac-utils/stac-task/issues/167)) Adds workflow-level
-  options to the ProcessDefinition object that are combined with each task's options,
-  giving precedence to the task options on conflict.
+  options to the ProcessDefinition object in a new `workflow_options` field. They are
+  combined with each task's options, giving precedence to the task options on conflict.
+- ([#167](https://github.com/stac-utils/stac-task/issues/167)) Adds a `workflow_options`
+  property to the `Task` class that returns the `workflow_options` dictionary from the
+  `ProcessDefinition` object.
+- ([#167](https://github.com/stac-utils/stac-task/issues/167)) Adds a `task_options`
+  property to the `Task` class that returns the task options from the `tasks` dictionary
+  in the `ProcessDefinition` object.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- ([#167](https://github.com/stac-utils/stac-task/issues/167)) Adds workflow-level
+  options to the ProcessDefinition object that are combined with each task's options,
+  giving precedence to the task options on conflict.
+
 ### Deprecated
 
-- ([#123](https://github.com/stac-utils/stac-task/issues/123)) Bare `ProcessDefinition`
+- ([#166](https://github.com/stac-utils/stac-task/issues/123)) Bare `ProcessDefinition`
   objects are deprecated in favor of arrays of `ProcessDefinition` objects.
 
 ## [0.6.0]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
       - [collections](#collections)
     - [tasks](#tasks)
     - [TaskConfig Object](#taskconfig-object)
+    - [workflow_options](#workflow_options)
   - [Full ProcessDefinition Example](#full-processdefinition-example)
 - [Migration](#migration)
   - [0.4.x -\> 0.5.x](#04x---05x)
@@ -76,12 +77,13 @@ Task input is often referred to as a 'payload'.
 A Task can be provided additional configuration via the 'process' field in the input
 payload.
 
-| Field Name     | Type               | Description                                    |
-| -------------- | ------------------ | ---------------------------------------------- |
-| description    | string             | Description of the process configuration       |
-| upload_options | `UploadOptions`    | An `UploadOptions` object                      |
-| tasks          | Map<str, Map>      | Dictionary of task configurations.             |
-| ~~tasks~~      | ~~[`TaskConfig`]~~ | **DEPRECATED** A list of `TaskConfig` objects. |
+| Field Name       | Type               | Description                                                              |
+| ---------------- | ------------------ | ------------------------------------------------------------------------ |
+| description      | string             | Description of the process configuration                                 |
+| upload_options   | `UploadOptions`    | An `UploadOptions` object                                                |
+| tasks            | Map<str, Map>      | Dictionary of task configurations.                                       |
+| ~~tasks~~        | ~~[`TaskConfig`]~~ | **DEPRECATED** A list of `TaskConfig` objects.                           |
+| workflow_options | Map<str, Any>      | Dictionary of configuration options applied to all tasks in the workflow |
 
 
 #### UploadOptions Object
@@ -162,6 +164,12 @@ for backwards compatibility.
 | name       | str           | **REQUIRED** Name of the task                                                       |
 | parameters | Map<str, str> | Dictionary of keyword parameters that will be passed to the Task `process` function |
 
+#### workflow_options
+
+The 'workflow_options' field is a dictionary of options that apply to all tasks in the
+workflow. The 'workflow_options' dictionary is combined with each task's option
+dictionary. If a key in the 'workflow_options' dictionary conflicts with a key in a
+task's option dictionary, the task option value takes precedence.
 
 ### Full ProcessDefinition Example
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -54,6 +54,40 @@ def test_deprecated_payload_dict(nothing_task: Task) -> None:
         nothing_task.process_definition
 
 
+def test_workflow_options_append_task_options(nothing_task: Task) -> None:
+    nothing_task._payload["process"][0]["workflow_options"] = {
+        "workflow_option": "workflow_option_value"
+    }
+    parameters = nothing_task.parameters
+    assert parameters == {
+        "do_nothing": True,
+        "workflow_option": "workflow_option_value",
+    }
+
+
+def test_workflow_options_populate_when_no_task_options(nothing_task: Task) -> None:
+    nothing_task._payload["process"][0]["tasks"].pop("nothing-task")
+    nothing_task._payload["process"][0]["workflow_options"] = {
+        "workflow_option": "workflow_option_value"
+    }
+    parameters = nothing_task.parameters
+    assert parameters == {
+        "workflow_option": "workflow_option_value",
+    }
+
+
+def test_task_options_supersede_workflow_options(nothing_task: Task) -> None:
+    nothing_task._payload["process"][0]["workflow_options"] = {
+        "do_nothing": False,
+        "workflow_option": "workflow_option_value",
+    }
+    parameters = nothing_task.parameters
+    assert parameters == {
+        "do_nothing": True,
+        "workflow_option": "workflow_option_value",
+    }
+
+
 def test_edit_items(nothing_task: Task) -> None:
     nothing_task.process_definition["workflow"] = "test-task-workflow"
     assert nothing_task._payload["process"][0]["workflow"] == "test-task-workflow"


### PR DESCRIPTION
**Related Issue(s):**

- #165 


**Proposed Changes:**

1. Adds a `workflow_options` dictionary of workflow-level options to the `ProcessDefinition` object. These options are combined with the options of each task in the workflow. If there is a conflict (same dictionary key), the task option value takes precedence.
2. Adds a `workflow_options` property to the `Task` class that returns the `workflow_options` dictionary from the `ProcessDefinition` object.
3. Adds a `task_options` property to the `Task` class that returns the task options from the `tasks` dictionary in the `ProcessDefinition` object.


**PR Checklist:**

- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
