### PR TITLE
Trigger docs build on release tag push to main

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 jobs:
   release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs = [
 Issues = "https://github.com/stac-utils/stactask/issues"
 Github = "https://github.com/stac-utils/stac-task"
 Changelog = "https://github.com/stac-utils/stac-task/blob/main/CHANGELOG.md"
+Documentation = "https://stac-task.readthedocs.io/en/stable/"
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
**Related Issue(s):**

- None


**Proposed Changes:**

1. Trigger full test suite run and docs build on release tag (tag that starts with `v`) push to main branch.
2. Only build and push release to pypi for tags that start with `v`.
3. Add Documentation link to pyproject.yaml (exposed on pypi)

**PR Checklist:**

- [x] ~~I have added my changes to the [CHANGELOG](https://github.com/stac-utils/stac-server/blob/main/CHANGELOG.md) **or**~~ a CHANGELOG entry is not required.
